### PR TITLE
[Auto] Update to Minecraft 1.21.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,9 @@ java_version=21
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.3
-yarn_mappings=1.21.3+build.2
-loader_version=0.16.8
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.8
+loader_version=0.16.10
 
 # Mod Properties
 # Note: this version number is updated during release
@@ -17,4 +17,4 @@ maven_group=co.secretonline.clientsidepaintingvariants
 archives_base_name=client-side-painting-variants
 
 # Dependencies
-fabric_version=0.106.1+1.21.3
+fabric_version=0.119.2+1.21.4

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,7 +4,9 @@
   "version": "${version}",
   "name": "Client side painting variants",
   "description": "Add your own painting variants, but completely client-side",
-  "authors": ["secret_online"],
+  "authors": [
+    "secret_online"
+  ],
   "license": "MPL-2.0",
   "icon": "assets/client-side-painting-variants/icon.png",
   "environment": "client",
@@ -28,8 +30,8 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.16.8",
-    "minecraft": "1.21.3"
+    "fabricloader": ">=0.16.10",
+    "minecraft": "1.21.4"
   },
   "custom": {
     "mc-publish": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.4` (Compatible: `1.21.3 - 1.21.4`)|
|Java|`21`|
|Yarn Mappings|`1.21.4+build.8`|
|Fabric API|`0.119.2+1.21.4`|
|Fabric Loader|`0.16.10`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

