### PR TITLE
[Auto] Update to Minecraft 1.21.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ maven_group=co.secretonline.clientsidepaintingvariants
 archives_base_name=client-side-painting-variants
 
 # Dependencies
-fabric_version=0.127.1+1.21.6
+fabric_version=0.128.0+1.21.6


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.6` (Compatible: `1.21.6`)|
|Java|`21`|
|Yarn Mappings|`1.21.6+build.1`|
|Fabric API|`0.128.0+1.21.6`|
|Fabric Loader|`0.16.14`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

