### PR TITLE
[Auto] Update to Minecraft 1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ java_version=21
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
 loader_version=0.16.14
 
 # Mod Properties
@@ -17,4 +17,4 @@ maven_group=co.secretonline.clientsidepaintingvariants
 archives_base_name=client-side-painting-variants
 
 # Dependencies
-fabric_version=0.127.1+1.21.6
+fabric_version=0.129.0+1.21.8

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   },
   "recommends": {
     "fabricloader": ">=0.16.14",
-    "minecraft": "1.21.6"
+    "minecraft": "1.21.8"
   },
   "custom": {
     "mc-publish": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.8` (Compatible: `~1.21.8`)|
|Java|`21`|
|Yarn Mappings|`1.21.8+build.1`|
|Fabric API|`0.129.0+1.21.8`|
|Fabric Loader|`0.16.14`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

