### PR TITLE
[Auto] Update to Minecraft 1.21.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ java_version=21
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.10
-loader_version=0.18.1
+minecraft_version=1.21.11
+loader_version=0.18.4
 
 # Mod Properties
 # Note: this version number is updated during release
@@ -16,4 +16,4 @@ maven_group=co.secretonline.clientsidepaintingvariants
 archives_base_name=client-side-painting-variants
 
 # Dependencies
-fabric_version=0.138.3+1.21.10
+fabric_version=0.141.3+1.21.11

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,8 +30,8 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.18.1",
-    "minecraft": "1.21.10"
+    "fabricloader": ">=0.18.4",
+    "minecraft": "1.21.11"
   },
   "custom": {
     "mc-publish": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.11` (Compatible: `~1.21.11`)|
|Java|`21`|
|Fabric API|`0.141.3+1.21.11`|
|Fabric Loader|`0.18.4`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

