### PR TITLE
[Auto] Update to Minecraft 26.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
-java_version=21
+java_version=25
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.10
-loader_version=0.18.1
+minecraft_version=26.1
+loader_version=0.18.5
 
 # Mod Properties
 # Note: this version number is updated during release
@@ -16,4 +16,4 @@ maven_group=co.secretonline.clientsidepaintingvariants
 archives_base_name=client-side-painting-variants
 
 # Dependencies
-fabric_version=0.138.3+1.21.10
+fabric_version=0.144.3+26.1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,12 +26,12 @@
   ],
   "accessWidener": "client-side-painting-variants.accesswidener",
   "depends": {
-    "java": ">=21",
+    "java": ">=25",
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.18.1",
-    "minecraft": "1.21.10"
+    "fabricloader": ">=0.18.5",
+    "minecraft": "26.1"
   },
   "custom": {
     "mc-publish": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`26.1` (Compatible: `~26.1`)|
|Java|`25`|
|Fabric API|`0.144.3+26.1`|
|Fabric Loader|`0.18.5`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

